### PR TITLE
Use one socket fd for an instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In your client code:
 
     require 'rubygems'
     require 'statsd'
-    STATSD = Statsd::Client.new('localhost',8125)
+    STATSD = Statsd::Client.new(:host => 'localhost', :port => 8125)
 
     STATSD.increment('some_counter') # basic incrementing
     STATSD.increment('system.nested_counter', 0.1) # incrementing with sampling (10%)
@@ -21,6 +21,27 @@ In your client code:
 
     STATSD.timing('some_job_time', 20) # reporting job that took 20ms
     STATSD.timing('some_job_time', 20, 0.05) # reporting job that took 20ms with sampling (5% sampling)
+
+There is an option for reduced DNS lookups, you can specify an additional
+constructor option `:resolve_always` and set it to `false`. By default, the
+client will always resolve the address unless `host` is set to 'localhost' or
+'127.0.0.1'.
+
+    require 'rubygems'
+    require 'statsd'
+
+    STATSD = Statsd::Client.new(:host => 'specialstats.host.example',
+                                :port => '8125',
+                                :resolve_always => false)
+
+    STATSD.increment('some_counter') # basic incrementing
+
+#### Note about thread-safety
+
+Since class variables and instance variables are not thread-safe on
+initialization, there is a potential for multiple UDP sockets being opened upon
+if you are using a truly multithreaded ruby, i.e. JRuby. Make sure to take that
+in to account when initializing this library.
 
 Guts
 ----

--- a/statsd.gemspec
+++ b/statsd.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "lookout-statsd"
-  s.version     = "1.0.0"
+  s.version     = "1.1.0"
   s.platform    = Gem::Platform::RUBY
 
   s.authors     = ['R. Tyler Croy', 'Andrew Coldham', 'Ben VandenBos']


### PR DESCRIPTION
Use one socket fd for an instance

The UDPSocket.new for every stat is inefficient and makes it difficult
to debug with strace since every stat that is sent requires 
files, dns lookups, etc.

This removes the file open/close and then gives an option of
`:lookup_always` to remove unneeded dns queries in the case of localhost
or a static A record.

I added a :resolve_always constructor option which does the following:
  - keeps backwards compatible API
  - forces sane defaults when not specified:
    - if localhost: default to only resolve the address on instantiation
    - if non-localhost: default to resolve every send_stats call
  - allows overriding the default behavior by simply setting the option

Documented punting thread-safety during initialization in the README, as
well as new :resolve_always.

Added a `connect` call to avoid resolving the host on every call to
`send`.

Bumps version to 1.1.0

Fixes #8