### PR TITLE
Implement batching for statsd

### DIFF
--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -190,4 +190,18 @@ describe Statsd::Client do
       c.gauge('foo' => 1)
     end
   end
+
+  describe '#batch' do
+    let(:c) { Statsd::Client.new }
+    subject { c.batch { |b| b.increment('foo'); b.increment('bar'); } }
+
+    it 'should take a block and put increments into a buffer' do
+      Statsd::Batch.any_instance do |b|
+        b.backlog.should_receive(:<<).exactly.twice
+      end
+      Statsd::Batch.any_instance.should_receive(:flush).and_call_original
+      c.should_receive(:send_data).once
+      subject
+    end
+  end
 end

--- a/statsd.gemspec
+++ b/statsd.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "lookout-statsd"
-  s.version     = "1.1.0"
+  s.version     = "2.0.0"
   s.platform    = Gem::Platform::RUBY
 
   s.authors     = ['R. Tyler Croy', 'Andrew Coldham', 'Ben VandenBos']


### PR DESCRIPTION
Batching is a missing functionality that most standard Ruby Statsd clients presently have.

This was implemented with inspiration from https://github.com/reinh/statsd/blob/master/lib/statsd.rb. 

We need this if we want to, for instance, implement historical metrics in Sidekiq Enterprise for an application that engages Statsd/Graphite using the lookout-rack-utils toolchain.