### PR TITLE
Explicitly require forwardable

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -1,5 +1,6 @@
 require 'socket'
 require 'resolv'
+require 'forwardable'
 
 module Statsd
   # initialize singleton instance in an initializer

--- a/statsd.gemspec
+++ b/statsd.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "lookout-statsd"
-  s.version     = "2.0.0"
+  s.version     = "2.0.1"
   s.platform    = Gem::Platform::RUBY
 
   s.authors     = ['R. Tyler Croy', 'Andrew Coldham', 'Ben VandenBos']


### PR DESCRIPTION
There are cases when forwardable isn't already required before we get to the definition 
of the Bulk class.  Specifically, this was the case for a JRuby 1.7.22 service.