### PR TITLE
Fix undefined method send_data (resolves #14)

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -82,6 +82,10 @@ module Statsd
                  })
     end
 
+    def send_data(*args)
+      @send_data.call(*args)
+    end
+
     # Creates and yields a Batch that can be used to batch instrument reports into
     # larger packets. Batches are sent either when the packet is "full" (defined
     # by batch_size), or when the block completes, whichever is the sooner.

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -18,10 +18,15 @@ describe Statsd do
       Statsd.instance.should_not be nil
     end
 
-    it 'should raise if called twice' do
-      Statsd.create_instance
-      expect { Statsd.create_instance }.to raise_error
+    context 'if an instance has been created' do
+      before :each do
+        Statsd.create_instance
+      end
+      it 'should raise if called twice' do
+        expect { Statsd.create_instance }.to raise_error
+      end
     end
+
   end
 
   describe '#instance' do

--- a/statsd.gemspec
+++ b/statsd.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "lookout-statsd"
-  s.version     = "2.0.0"
+  s.version     = "2.0.2"
   s.platform    = Gem::Platform::RUBY
 
   s.authors     = ['R. Tyler Croy', 'Andrew Coldham', 'Ben VandenBos']


### PR DESCRIPTION
For some reason, ::Statsd::Client doesn't like a bare invocation of send_data. This fixes it by wrapping @send_data in a send_data method that invokes it.  Let's merge this after @avalade's change is in.