### PR TITLE
Update #gauge to be compabitible with other statsd clients

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -73,14 +73,26 @@ module Statsd
       send_stats(stats.map { |s| "#{p}#{s}:#{delta}|c" }, sample_rate)
     end
 
-    # +stats+ is a hash
-    def gauge(stats)
-      send_stats(stats.map { |s,val|
-                   if @prefix
-                     s = "#{@prefix}.#{s}"
-                   end
-                   "#{s}:#{val}|g"
-                 })
+    # +stat_or_stats+ may either be a Hash OR a String. If it's a
+    # String, then value must be specified. Other statsd client gems
+    # have mostly standardized on using the String+value format, but
+    # this gem traditionally supported just a Hash. This now supports
+    # both for compatibility.
+    def gauge(stat_or_stats, value=nil, opts=nil)
+      # Can't use duck-typing here, since String responds to :map
+      if stat_or_stats.is_a?(Hash)
+        send_stats(stat_or_stats.map { |s,val|
+                     if @prefix
+                       s = "#{@prefix}.#{s}"
+                     end
+                     "#{s}:#{val}|g"
+                   })
+      else
+        if @prefix
+          stat_or_stats = "#{@prefix}.#{stat_or_stats}"
+        end
+        send_stats("#{stat_or_stats}:#{value}|g")
+      end
     end
 
     def send_data(*args)

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -181,18 +181,50 @@ describe Statsd::Client do
   describe '#gauge' do
     let(:c) { Statsd::Client.new }
 
-    it 'should encode the values correctly' do
-      c.should_receive(:send_stats).with do |array|
-        array.should include('foo:1|g')
-        array.should include('bar:2|g')
+    context "called with a Hash" do
+      it 'should encode the values correctly' do
+        c.should_receive(:send_stats).with do |array|
+          array.should include('foo:1|g')
+          array.should include('bar:2|g')
+        end
+        c.gauge('foo' => 1, 'bar' => 2)
       end
-      c.gauge('foo' => 1, 'bar' => 2)
+
+      it 'should prepend the prefix if it has one' do
+        c.prefix = 'dev'
+        c.should_receive(:send_stats).with(['dev.foo:1|g'])
+        c.gauge('foo' => 1)
+      end
     end
 
-    it 'should prepend the prefix if it has one' do
-      c.prefix = 'dev'
-      c.should_receive(:send_stats).with(['dev.foo:1|g'])
-      c.gauge('foo' => 1)
+    context "called with String+Value" do
+      context "without specifying options" do
+        it 'should encode the values correctly' do
+          c.should_receive(:send_stats).with('foo:1|g')
+          c.gauge('foo', 1)
+        end
+
+        it 'should prepend the prefix if it has one' do
+          c.prefix = 'dev'
+          c.should_receive(:send_stats).with('dev.foo:1|g')
+          c.gauge('foo', 1)
+        end
+      end
+
+      context "specifying options" do
+        let(:opts) { {:ignored => true} }
+
+        it 'should encode the values correctly' do
+          c.should_receive(:send_stats).with('foo:1|g')
+          c.gauge('foo', 1, opts)
+        end
+
+        it 'should prepend the prefix if it has one' do
+          c.prefix = 'dev'
+          c.should_receive(:send_stats).with('dev.foo:1|g')
+          c.gauge('foo', 1, opts)
+        end
+      end
     end
   end
 

--- a/statsd.gemspec
+++ b/statsd.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "lookout-statsd"
-  s.version     = "2.0.3"
+  s.version     = "2.1.0"
   s.platform    = Gem::Platform::RUBY
 
   s.authors     = ['R. Tyler Croy', 'Andrew Coldham', 'Ben VandenBos']


### PR DESCRIPTION
This gem has traditionally required gauge to be a Hash, but other ruby
statsd client gems have passed in a String and a value. This adds
support for both formats simultaneously to make this gem more
interchangeable with other gems.