### PR TITLE
Add Statsd.set_instance to allow using another impl

### DIFF
--- a/lib/lookout/statsd.rb
+++ b/lib/lookout/statsd.rb
@@ -2,41 +2,41 @@ require 'socket'
 require 'resolv'
 require 'forwardable'
 
-class Statsd
-  # initialize singleton instance to be an instance of
-  # +LookoutStatsd::Client+, with the given options
-  def self.create_instance(opts={})
-    raise "Already initialized Statsd" if instance_set?
-    @@instance ||= LookoutStatsd::Client.new(opts)
+module Lookout
+  class Statsd
+    # initialize singleton instance to be an instance of
+    # +Lookout::StatsdClient+, with the given options
+    def self.create_instance(opts={})
+      raise "Already initialized Statsd" if instance_set?
+      @@instance ||= StatsdClient.new(opts)
+    end
+
+    # Explicitly set singleton instance. The instance must follow the
+    # same API as +Lookout::StatsdClient+
+    def self.set_instance(instance)
+      raise "Already initialized Statsd" if instance_set?
+      @@instance = instance
+    end
+
+    # Clear singleton instance, for use in testing ONLY
+    def self.clear_instance
+      @@instance = nil
+    end
+
+    # Check if the instance has been set
+    def self.instance_set?
+      defined?(@@instance) && !!@@instance
+    end
+
+    # Access singleton instance, which must have been initialized with
+    # .create_instance or .set_instance
+    def self.instance
+      raise "Statsd has not been initialized" unless instance_set?
+      @@instance
+    end
   end
 
-  # Explicitly set singleton instance. The instance must follow the
-  # same API as +LookoutStatsd::Client+
-  def self.set_instance(instance)
-    raise "Already initialized Statsd" if instance_set?
-    @@instance = instance
-  end
-
-  # Clear singleton instance, for use in testing ONLY
-  def self.clear_instance
-    @@instance = nil
-  end
-
-  # Check if the instance has been set
-  def self.instance_set?
-    defined?(@@instance) && !!@@instance
-  end
-
-  # Access singleton instance, which must have been initialized with
-  # .create_instance or .set_instance
-  def self.instance
-    raise "Statsd has not been initialized" unless instance_set?
-    @@instance
-  end
-end
-
-module LookoutStatsd
-  class Client
+  class StatsdClient
     attr_accessor :host, :port, :prefix, :resolve_always, :batch_size
 
     def initialize(opts={})
@@ -203,7 +203,7 @@ module LookoutStatsd
   # that some care is taken if setting very large batch sizes. If the batch size
   # exceeds the allowed packet size for UDP on your network, communication
   # troubles may occur and data will be lost.
-  class Batch < LookoutStatsd::Client
+  class Batch < Lookout::StatsdClient
 
     attr_accessor :batch_size
 
@@ -261,9 +261,8 @@ module LookoutStatsd
         # Use params[:controller] insted of controller.controller_name to get full path.
         controller_name = controller.params[:controller].gsub("/", ".")
         key = "requests.#{controller_name}.#{controller.params[:action]}"
-        Statsd.instance.timing(key, &block)
+        Lookout::Statsd.instance.timing(key, &block)
       end
     end
   end
-
 end

--- a/lib/statsd/test.rb
+++ b/lib/statsd/test.rb
@@ -1,3 +1,0 @@
-require 'statsd'
-counters = timers = []
-#Statsd::Graphite.flush_stats(counters,timers)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,3 @@
 $:.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 
-require 'statsd'
+require 'lookout/statsd'

--- a/spec/statsd/rails/action_timer_filter_spec.rb
+++ b/spec/statsd/rails/action_timer_filter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Statsd::Rails::ActionTimerFilter do
+describe LookoutStatsd::Rails::ActionTimerFilter do
 
   describe ".filter" do
     before(:all) do
@@ -10,13 +10,13 @@ describe Statsd::Rails::ActionTimerFilter do
     it "should log the appropriate data with simple controller" do
       controller = mock_controller('control', 'act')
       Statsd.instance.should_receive(:timing).with("requests.control.act")
-      Statsd::Rails::ActionTimerFilter.filter(controller) {}
+      LookoutStatsd::Rails::ActionTimerFilter.filter(controller) {}
     end
 
     it "should log the appropriate data with complex controller" do
       controller = mock_controller('api/v1/control', 'act')
       Statsd.instance.should_receive(:timing).with("requests.api.v1.control.act")
-      Statsd::Rails::ActionTimerFilter.filter(controller) {}
+      LookoutStatsd::Rails::ActionTimerFilter.filter(controller) {}
     end
   end
 

--- a/spec/statsd/rails/action_timer_filter_spec.rb
+++ b/spec/statsd/rails/action_timer_filter_spec.rb
@@ -1,22 +1,22 @@
 require 'spec_helper'
 
-describe LookoutStatsd::Rails::ActionTimerFilter do
+describe Lookout::Rails::ActionTimerFilter do
 
   describe ".filter" do
     before(:all) do
-      Statsd.create_instance
+      Lookout::Statsd.create_instance
     end
 
     it "should log the appropriate data with simple controller" do
       controller = mock_controller('control', 'act')
-      Statsd.instance.should_receive(:timing).with("requests.control.act")
-      LookoutStatsd::Rails::ActionTimerFilter.filter(controller) {}
+      Lookout::Statsd.instance.should_receive(:timing).with("requests.control.act")
+      Lookout::Rails::ActionTimerFilter.filter(controller) {}
     end
 
     it "should log the appropriate data with complex controller" do
       controller = mock_controller('api/v1/control', 'act')
-      Statsd.instance.should_receive(:timing).with("requests.api.v1.control.act")
-      LookoutStatsd::Rails::ActionTimerFilter.filter(controller) {}
+      Lookout::Statsd.instance.should_receive(:timing).with("requests.api.v1.control.act")
+      Lookout::Rails::ActionTimerFilter.filter(controller) {}
     end
   end
 

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Statsd do
+describe Lookout::Statsd do
   before(:each) do
     described_class.clear_instance
   end
@@ -11,16 +11,16 @@ describe Statsd do
 
   describe '.create_instance' do
     it 'should create an instance' do
-      Statsd.create_instance
-      Statsd.instance.should_not be nil
+      described_class.create_instance
+      described_class.instance.should_not be nil
     end
 
     context 'if an instance has been created' do
       before :each do
-        Statsd.create_instance
+        described_class.create_instance
       end
       it 'should raise if called twice' do
-        expect { Statsd.create_instance }.to raise_error
+        expect { described_class.create_instance }.to raise_error
       end
     end
   end
@@ -29,55 +29,55 @@ describe Statsd do
     let(:instance) { double('Statsd') }
 
     it 'should set instance' do
-      Statsd.set_instance(instance)
-      expect(Statsd.instance).to eq instance
+      described_class.set_instance(instance)
+      expect(described_class.instance).to eq instance
     end
 
     context 'if an instance has been created' do
       before :each do
-        Statsd.set_instance(instance)
+        described_class.set_instance(instance)
       end
       it 'should raise if called twice' do
-        expect { Statsd.set_instance(instance) }.to raise_error
+        expect { described_class.set_instance(instance) }.to raise_error
       end
     end
   end
 
   describe '#instance' do
     it 'should raise if not created' do
-      expect { Statsd.instance }.to raise_error
+      expect { described_class.instance }.to raise_error
     end
   end
 end
 
-describe LookoutStatsd::Client do
+describe Lookout::StatsdClient do
   describe '#initialize' do
     it 'should work without arguments' do
-      c = LookoutStatsd::Client.new
+      c = Lookout::StatsdClient.new
       c.should_not be nil
     end
 
     it 'should accept a :host keyword argument' do
       host = 'zombo.com'
-      c = LookoutStatsd::Client.new(:host => host)
+      c = Lookout::StatsdClient.new(:host => host)
       c.host.should match(host)
     end
 
     it 'should accept a :port keyword argument' do
       port = 1337
-      c = LookoutStatsd::Client.new(:port => port)
+      c = Lookout::StatsdClient.new(:port => port)
       c.port.should == port
     end
 
     it 'should accept a :prefix keyword argument' do
       prefix = 'dev'
-      c = LookoutStatsd::Client.new(:prefix => prefix)
+      c = Lookout::StatsdClient.new(:prefix => prefix)
       c.prefix.should match(prefix)
     end
 
     it 'should accept a :resolve_always keyword argument' do
       lookup = false
-      c = LookoutStatsd::Client.new(:resolve_always => lookup)
+      c = Lookout::StatsdClient.new(:resolve_always => lookup)
       c.resolve_always.should be(lookup)
     end
 
@@ -85,14 +85,14 @@ describe LookoutStatsd::Client do
 
       context 'when host is localhost or 127.0.0.1' do
         it ':resolve_always should default to false' do
-          c = LookoutStatsd::Client.new(:host => 'localhost')
+          c = Lookout::StatsdClient.new(:host => 'localhost')
           c.resolve_always.should be(false)
         end
       end
 
       context 'when host is not local' do
         it ':resolve_always should default to true' do
-          c = LookoutStatsd::Client.new(:host => 'statsd.example.example')
+          c = Lookout::StatsdClient.new(:host => 'statsd.example.example')
           c.resolve_always.should be(true)
         end
       end
@@ -104,14 +104,14 @@ describe LookoutStatsd::Client do
   describe '#send_stats' do
 
     it 'should use cached resolve address when :resolve_always is false' do
-      c = LookoutStatsd::Client.new(:resolve_always => false)
+      c = Lookout::StatsdClient.new(:resolve_always => false)
       sock = c.instance_variable_get(:@socket)
       expect(sock).to receive(:send).with(anything, 0)
       c.increment('foo')
     end
 
     it 'should always resolve address when :resolve_always is true' do
-      c = LookoutStatsd::Client.new(:resolve_always => true)
+      c = Lookout::StatsdClient.new(:resolve_always => true)
       sock = c.instance_variable_get(:@socket)
       expect(sock).to receive(:send).with(anything, 0, c.host, c.port)
       c.increment('foo')
@@ -119,7 +119,7 @@ describe LookoutStatsd::Client do
   end
 
   describe '#timing' do
-    let(:c) { LookoutStatsd::Client.new }
+    let(:c) { Lookout::StatsdClient.new }
 
     it 'should pass the sample rate along' do
       sample = 10
@@ -159,7 +159,7 @@ describe LookoutStatsd::Client do
   end
 
   describe '#increment' do
-    let(:c) { LookoutStatsd::Client.new }
+    let(:c) { Lookout::StatsdClient.new }
 
     it 'should update the counter by 1' do
       c.should_receive(:update_counter).with('foo', 1, anything())
@@ -168,7 +168,7 @@ describe LookoutStatsd::Client do
   end
 
   describe '#decrement' do
-    let(:c) { LookoutStatsd::Client.new }
+    let(:c) { Lookout::StatsdClient.new }
 
     it 'should update the counter by -1' do
       c.should_receive(:update_counter).with('foo', -1, anything())
@@ -177,7 +177,7 @@ describe LookoutStatsd::Client do
   end
 
   describe '#update_counter' do
-    let(:c) { LookoutStatsd::Client.new }
+    let(:c) { Lookout::StatsdClient.new }
 
     it 'should prepend the prefix if it has one' do
       c.prefix = 'dev'
@@ -193,7 +193,7 @@ describe LookoutStatsd::Client do
   end
 
   describe '#gauge' do
-    let(:c) { LookoutStatsd::Client.new }
+    let(:c) { Lookout::StatsdClient.new }
 
     context "called with a Hash" do
       it 'should encode the values correctly' do
@@ -243,22 +243,22 @@ describe LookoutStatsd::Client do
   end
 
   describe '#batch' do
-    let(:c) { LookoutStatsd::Client.new }
+    let(:c) { Lookout::StatsdClient.new }
     subject { c.batch { |b| b.increment('foo'); b.increment('bar'); } }
 
     it 'should take a block and put increments into a buffer' do
-      LookoutStatsd::Batch.any_instance do |b|
+      Lookout::Batch.any_instance do |b|
         b.backlog.should_receive(:<<).exactly.twice
       end
-      LookoutStatsd::Batch.any_instance.should_receive(:flush).and_call_original
+      Lookout::Batch.any_instance.should_receive(:flush).and_call_original
       c.should_receive(:send_data).once
       subject
     end
   end
 end
 
-describe LookoutStatsd::Batch do
-  let(:c) { LookoutStatsd::Client.new :host => 'foo.com', :prefix => 'my.app', :port => 1234, :batch_size => 20 }
+describe Lookout::Batch do
+  let(:c) { Lookout::StatsdClient.new :host => 'foo.com', :prefix => 'my.app', :port => 1234, :batch_size => 20 }
 
   it 'should delegate fields correctly' do
     c.batch do |b|

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -1,18 +1,15 @@
 require 'spec_helper'
 
 describe Statsd do
-  describe '#create_instance' do
-    before(:each) do
-      # Make sure prior test hasn't already invoked create_instance
-      if Statsd.class_variable_defined?(:@@instance)
-        Statsd.send(:remove_class_variable, :@@instance)
-      end
-    end
+  before(:each) do
+    described_class.clear_instance
+  end
 
-    after(:each) do
-      Statsd.send(:remove_class_variable, :@@instance)
-    end
+  after(:each) do
+    described_class.clear_instance
+  end
 
+  describe '.create_instance' do
     it 'should create an instance' do
       Statsd.create_instance
       Statsd.instance.should_not be nil
@@ -26,7 +23,24 @@ describe Statsd do
         expect { Statsd.create_instance }.to raise_error
       end
     end
+  end
 
+  describe '.set_instance' do
+    let(:instance) { double('Statsd') }
+
+    it 'should set instance' do
+      Statsd.set_instance(instance)
+      expect(Statsd.instance).to eq instance
+    end
+
+    context 'if an instance has been created' do
+      before :each do
+        Statsd.set_instance(instance)
+      end
+      it 'should raise if called twice' do
+        expect { Statsd.set_instance(instance) }.to raise_error
+      end
+    end
   end
 
   describe '#instance' do
@@ -36,34 +50,34 @@ describe Statsd do
   end
 end
 
-describe Statsd::Client do
+describe LookoutStatsd::Client do
   describe '#initialize' do
     it 'should work without arguments' do
-      c = Statsd::Client.new
+      c = LookoutStatsd::Client.new
       c.should_not be nil
     end
 
     it 'should accept a :host keyword argument' do
       host = 'zombo.com'
-      c = Statsd::Client.new(:host => host)
+      c = LookoutStatsd::Client.new(:host => host)
       c.host.should match(host)
     end
 
     it 'should accept a :port keyword argument' do
       port = 1337
-      c = Statsd::Client.new(:port => port)
+      c = LookoutStatsd::Client.new(:port => port)
       c.port.should == port
     end
 
     it 'should accept a :prefix keyword argument' do
       prefix = 'dev'
-      c = Statsd::Client.new(:prefix => prefix)
+      c = LookoutStatsd::Client.new(:prefix => prefix)
       c.prefix.should match(prefix)
     end
 
     it 'should accept a :resolve_always keyword argument' do
       lookup = false
-      c = Statsd::Client.new(:resolve_always => lookup)
+      c = LookoutStatsd::Client.new(:resolve_always => lookup)
       c.resolve_always.should be(lookup)
     end
 
@@ -71,14 +85,14 @@ describe Statsd::Client do
 
       context 'when host is localhost or 127.0.0.1' do
         it ':resolve_always should default to false' do
-          c = Statsd::Client.new(:host => 'localhost')
+          c = LookoutStatsd::Client.new(:host => 'localhost')
           c.resolve_always.should be(false)
         end
       end
 
       context 'when host is not local' do
         it ':resolve_always should default to true' do
-          c = Statsd::Client.new(:host => 'statsd.example.example')
+          c = LookoutStatsd::Client.new(:host => 'statsd.example.example')
           c.resolve_always.should be(true)
         end
       end
@@ -90,14 +104,14 @@ describe Statsd::Client do
   describe '#send_stats' do
 
     it 'should use cached resolve address when :resolve_always is false' do
-      c = Statsd::Client.new(:resolve_always => false)
+      c = LookoutStatsd::Client.new(:resolve_always => false)
       sock = c.instance_variable_get(:@socket)
       expect(sock).to receive(:send).with(anything, 0)
       c.increment('foo')
     end
 
     it 'should always resolve address when :resolve_always is true' do
-      c = Statsd::Client.new(:resolve_always => true)
+      c = LookoutStatsd::Client.new(:resolve_always => true)
       sock = c.instance_variable_get(:@socket)
       expect(sock).to receive(:send).with(anything, 0, c.host, c.port)
       c.increment('foo')
@@ -105,7 +119,7 @@ describe Statsd::Client do
   end
 
   describe '#timing' do
-    let(:c) { Statsd::Client.new }
+    let(:c) { LookoutStatsd::Client.new }
 
     it 'should pass the sample rate along' do
       sample = 10
@@ -145,7 +159,7 @@ describe Statsd::Client do
   end
 
   describe '#increment' do
-    let(:c) { Statsd::Client.new }
+    let(:c) { LookoutStatsd::Client.new }
 
     it 'should update the counter by 1' do
       c.should_receive(:update_counter).with('foo', 1, anything())
@@ -154,7 +168,7 @@ describe Statsd::Client do
   end
 
   describe '#decrement' do
-    let(:c) { Statsd::Client.new }
+    let(:c) { LookoutStatsd::Client.new }
 
     it 'should update the counter by -1' do
       c.should_receive(:update_counter).with('foo', -1, anything())
@@ -163,7 +177,7 @@ describe Statsd::Client do
   end
 
   describe '#update_counter' do
-    let(:c) { Statsd::Client.new }
+    let(:c) { LookoutStatsd::Client.new }
 
     it 'should prepend the prefix if it has one' do
       c.prefix = 'dev'
@@ -179,7 +193,7 @@ describe Statsd::Client do
   end
 
   describe '#gauge' do
-    let(:c) { Statsd::Client.new }
+    let(:c) { LookoutStatsd::Client.new }
 
     context "called with a Hash" do
       it 'should encode the values correctly' do
@@ -229,22 +243,22 @@ describe Statsd::Client do
   end
 
   describe '#batch' do
-    let(:c) { Statsd::Client.new }
+    let(:c) { LookoutStatsd::Client.new }
     subject { c.batch { |b| b.increment('foo'); b.increment('bar'); } }
 
     it 'should take a block and put increments into a buffer' do
-      Statsd::Batch.any_instance do |b|
+      LookoutStatsd::Batch.any_instance do |b|
         b.backlog.should_receive(:<<).exactly.twice
       end
-      Statsd::Batch.any_instance.should_receive(:flush).and_call_original
+      LookoutStatsd::Batch.any_instance.should_receive(:flush).and_call_original
       c.should_receive(:send_data).once
       subject
     end
   end
 end
 
-describe Statsd::Batch do
-  let(:c) { Statsd::Client.new :host => 'foo.com', :prefix => 'my.app', :port => 1234, :batch_size => 20 }
+describe LookoutStatsd::Batch do
+  let(:c) { LookoutStatsd::Client.new :host => 'foo.com', :prefix => 'my.app', :port => 1234, :batch_size => 20 }
 
   it 'should delegate fields correctly' do
     c.batch do |b|

--- a/statsd.gemspec
+++ b/statsd.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "lookout-statsd"
-  s.version     = "2.1.0"
+  s.version     = "3.0.0"
   s.platform    = Gem::Platform::RUBY
 
   s.authors     = ['R. Tyler Croy', 'Andrew Coldham', 'Ben VandenBos']


### PR DESCRIPTION
This is a major version bump since it changes Statsd from a Module to a
Class, to allow another Statsd implementation to be loaded onto the same
class. It moves Statsd::Client to LookoutStatsd::Client, and
create_instance will create one of those by default, but the new
Statsd.set_instance allows callers to specify what Statsd object will be
returned by Statsd.instance.