### PR TITLE
Add #time to Lookout::StatsdClient for compatibility

### DIFF
--- a/lib/lookout/statsd.rb
+++ b/lib/lookout/statsd.rb
@@ -77,6 +77,15 @@ module Lookout
       value
     end
 
+    # +stat+ to log timing for, from provided block
+    def time(stat, sample_rate = 1)
+      start_time = Time.now.to_f
+      value = yield
+    ensure
+      timing(stat, ((Time.now.to_f - start_time) * 1000).floor, sample_rate)
+      value
+    end
+
     # +stats+ can be a string or an array of strings
     def increment(stats, sample_rate = 1)
       update_counter stats, 1, sample_rate

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -158,6 +158,32 @@ describe Lookout::StatsdClient do
     end
   end
 
+  describe '#time' do
+    let(:c) { Lookout::StatsdClient.new }
+    let(:value) { 1337 }
+    let(:sample_rate) { 3 }
+
+    before :each do
+      # Pretend our block took one second
+      Time.stub_chain(:now, :to_f).and_return(1, 2)
+    end
+
+    it 'should wrap a block correctly' do
+      expect(c).to receive(:timing).with('foo', 1000, 1)
+      c.time('foo') { true }
+    end
+
+    it 'should pass along sample rate' do
+      expect(c).to receive(:timing).with('foo', 1000, sample_rate)
+      c.time('foo', sample_rate) { true }
+    end
+
+    it 'should return the return value from the block' do
+      value = c.time('foo') { value }
+      expect(value).to eq value
+    end
+  end
+
   describe '#increment' do
     let(:c) { Lookout::StatsdClient.new }
 

--- a/statsd.gemspec
+++ b/statsd.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "lookout-statsd"
-  s.version     = "3.0.0"
+  s.version     = "3.1.0"
   s.platform    = Gem::Platform::RUBY
 
   s.authors     = ['R. Tyler Croy', 'Andrew Coldham', 'Ben VandenBos']


### PR DESCRIPTION
Other Statsd implementations use #time where we've been using #timing
This adds #time. Our #timing doesn't have a strictly matching API, but
it's compatible. This will require all callers to change the APIs they
use, if they want to be compatible.