### PR TITLE
Add #count to Lookout::StatsdClient for compatibility

### DIFF
--- a/lib/lookout/statsd.rb
+++ b/lib/lookout/statsd.rb
@@ -103,6 +103,8 @@ module Lookout
       send_stats(stats.map { |s| "#{p}#{s}:#{delta}|c" }, sample_rate)
     end
 
+    alias_method :count, :update_counter
+
     # +stat_or_stats+ may either be a Hash OR a String. If it's a
     # String, then value must be specified. Other statsd client gems
     # have mostly standardized on using the String+value format, but

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -218,6 +218,15 @@ describe Lookout::StatsdClient do
     end
   end
 
+  describe '#count' do
+    let(:c) { Lookout::StatsdClient.new }
+
+    it 'should behave like update_counter' do
+      c.should_receive(:send_stats).with(['foo:123|c'], 1)
+      c.update_counter('foo', 123, 1)
+    end
+  end
+
   describe '#gauge' do
     let(:c) { Lookout::StatsdClient.new }
 

--- a/statsd.gemspec
+++ b/statsd.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "lookout-statsd"
-  s.version     = "3.1.0"
+  s.version     = "3.2.0"
   s.platform    = Gem::Platform::RUBY
 
   s.authors     = ['R. Tyler Croy', 'Andrew Coldham', 'Ben VandenBos']


### PR DESCRIPTION
Just an alias to #update_counter, but continues work to be compatible
with other Statsd implementations.
